### PR TITLE
Renamed function spi_transfer to spi_transfer_SW, and added...

### DIFF
--- a/gateway/radioPinFunctions.c
+++ b/gateway/radioPinFunctions.c
@@ -11,6 +11,48 @@
 
 #include <avr/io.h>
 
+//#define USE_HARDWARE_SPI
+
+//IO pin register and bit mapping
+#define NRF24_DDR_MISO	DDRC
+#define NRF24_PORT_MISO	PORTC
+#define NRF24_PIN_MISO	PINC
+#define NRF24_BIT_MISO	4
+#define NRF24_DDR_MOSI	DDRC
+#define NRF24_PORT_MOSI	PORTC
+#define NRF24_BIT_MOSI	3
+#define NRF24_DDR_SCK	  DDRC
+#define NRF24_PORT_SCK	PORTC
+#define NRF24_BIT_SCK	  2
+#define NRF24_DDR_CS	  DDRC
+#define NRF24_PORT_CS	  PORTC
+#define NRF24_BIT_CS	  1
+#define NRF24_DDR_CE	  DDRC
+#define NRF24_PORT_CE	  PORTC
+#define NRF24_BIT_CE	  0
+
+//IRQ pin (currently not used)
+#define NRF24_DDR_IRQ	  DDRB
+#define NRF24_PORT_IRQ	PORTB
+#define NRF24_BIT_IRQ	  2
+
+//SPI register and bit remapping (some have SPCR, others SPCR0, etc.)
+#define NRF24_SPCR	SPCR0
+#define NRF24_SPIE  SPIE
+#define NRF24_SPE   SPE
+#define NRF24_DORD  DORD
+#define NRF24_MSTR  MSTR
+#define NRF24_CPOL  CPOL
+#define NRF24_CPHA  CPHA
+#define NRF24_SPR0  SPR0
+
+#define NRF24_SPSR	SPSR0
+#define NRF24_SPIF  SPIF
+#define NRF24_SPI2X SPI2X
+
+#define NRF24_SPDR	SPDR0
+
+
 #define set_bit(reg,bit) reg |= (1<<bit)
 #define clr_bit(reg,bit) reg &= ~(1<<bit)
 #define check_bit(reg,bit) (reg&(1<<bit))
@@ -18,22 +60,27 @@
 /* ------------------------------------------------------------------------- */
 void nrf24_setupPins()
 {
-    set_bit(DDRC,0); // CE output
-    set_bit(DDRC,1); // CSN output
-    set_bit(DDRC,2); // SCK output
-    set_bit(DDRC,3); // MOSI output
-    clr_bit(DDRC,4); // MISO input
+  set_bit(NRF24_DDR_CE,NRF24_BIT_CE); // CE output
+  set_bit(NRF24_DDR_CS,NRF24_BIT_CS); // CSN output
+  set_bit(NRF24_DDR_SCK,NRF24_BIT_SCK); // SCK output
+  set_bit(NRF24_DDR_MOSI,NRF24_BIT_MOSI); // MOSI output
+  clr_bit(NRF24_DDR_MISO,NRF24_BIT_MISO); // MISO input
+
+#ifdef USE_HARDWARE_SPI
+	NRF24_SPCR = (0<<NRF24_SPIE) | (1<<NRF24_SPE) | (0<<NRF24_DORD) | (1<<NRF24_MSTR) | (0<< NRF24_CPOL) | (0<<NRF24_CPHA) | (0<<NRF24_SPR0);
+	NRF24_SPSR = (1<<NRF24_SPI2X);
+#endif
 }
 /* ------------------------------------------------------------------------- */
 void nrf24_ce_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTC,0);
+        set_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
     else
     {
-        clr_bit(PORTC,0);
+        clr_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -41,11 +88,11 @@ void nrf24_csn_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTC,1);
+        set_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
     else
     {
-        clr_bit(PORTC,1);
+        clr_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -53,11 +100,11 @@ void nrf24_sck_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTC,2);
+        set_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
     else
     {
-        clr_bit(PORTC,2);
+        clr_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -65,16 +112,34 @@ void nrf24_mosi_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTC,3);
+        set_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
     else
     {
-        clr_bit(PORTC,3);
+        clr_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
 }
 /* ------------------------------------------------------------------------- */
 uint8_t nrf24_miso_digitalRead()
 {
-    return check_bit(PINC,4);
+    return check_bit(NRF24_PIN_MISO,NRF24_BIT_MISO);
+}
+/* ------------------------------------------------------------------------- */
+
+#ifndef USE_HARDWARE_SPI
+extern uint8_t spi_transfer_SW(uint8_t tx);
+#endif
+uint8_t spi_transfer(uint8_t tx)
+{
+#ifdef USE_HARDWARE_SPI
+  uint8_t rx = 0;
+
+  NRF24_SPDR = tx;
+  while ( !(NRF24_SPSR & (1<<NRF24_SPIF)) ) {} //wait until done
+  rx = NRF24_SPDR;
+  return rx;
+#else
+  return spi_transfer_SW(tx);
+#endif
 }
 /* ------------------------------------------------------------------------- */

--- a/nrf24.c
+++ b/nrf24.c
@@ -265,7 +265,7 @@ void nrf24_powerDown()
 }
 
 /* software spi routine */
-uint8_t spi_transfer(uint8_t tx)
+uint8_t spi_transfer_SW(uint8_t tx)
 {
     uint8_t i = 0;
     uint8_t rx = 0;    

--- a/nrf24.h
+++ b/nrf24.h
@@ -57,8 +57,10 @@ void    nrf24_powerUpRx();
 void    nrf24_powerUpTx();
 void    nrf24_powerDown();
 
+/* low level SPI bit-banging fall-back function*/
+uint8_t spi_transfer_SW(uint8_t tx);
+
 /* low level interface ... */
-uint8_t spi_transfer(uint8_t tx);
 void    nrf24_transmitSync(uint8_t* dataout,uint8_t len);
 void    nrf24_transferSync(uint8_t* dataout,uint8_t* datain,uint8_t len);
 void    nrf24_configRegister(uint8_t reg, uint8_t value);
@@ -109,8 +111,16 @@ extern void nrf24_mosi_digitalWrite(uint8_t state);
 
 /* -------------------------------------------------------------------------- */
 /* nrf24 MISO pin read function
-/* - returns: Non-zero if the pin is high */
+ * - returns: Non-zero if the pin is high */
 /* -------------------------------------------------------------------------- */
 extern uint8_t nrf24_miso_digitalRead();
+
+/* -------------------------------------------------------------------------- */
+/* nrf24 SPI data transfer function
+ * - should either implement an spi transfer or a call software fallback
+ *   function provided by the library: uint8_t spi_transfer_SW(uint8_t tx);
+ * - returns: received data */
+/* -------------------------------------------------------------------------- */
+extern uint8_t spi_transfer(uint8_t tx);
 
 #endif

--- a/rx_example/radioPinFunctions.c
+++ b/rx_example/radioPinFunctions.c
@@ -11,6 +11,48 @@
 
 #include <avr/io.h>
 
+//#define USE_HARDWARE_SPI
+
+//IO pin register and bit mapping
+#define NRF24_DDR_MISO	DDRA
+#define NRF24_PORT_MISO	PORTA
+#define NRF24_PIN_MISO	PINA
+#define NRF24_BIT_MISO	4
+#define NRF24_DDR_MOSI	DDRA
+#define NRF24_PORT_MOSI	PORTA
+#define NRF24_BIT_MOSI	3
+#define NRF24_DDR_SCK	  DDRA
+#define NRF24_PORT_SCK	PORTA
+#define NRF24_BIT_SCK	  2
+#define NRF24_DDR_CS	  DDRA
+#define NRF24_PORT_CS	  PORTA
+#define NRF24_BIT_CS	  1
+#define NRF24_DDR_CE	  DDRA
+#define NRF24_PORT_CE	  PORTA
+#define NRF24_BIT_CE	  0
+
+//IRQ pin (currently not used)
+#define NRF24_DDR_IRQ	  DDRB
+#define NRF24_PORT_IRQ	PORTB
+#define NRF24_BIT_IRQ	  2
+
+//SPI register and bit remapping (some have SPCR, others SPCR0, etc.)
+#define NRF24_SPCR	SPCR0
+#define NRF24_SPIE  SPIE
+#define NRF24_SPE   SPE
+#define NRF24_DORD  DORD
+#define NRF24_MSTR  MSTR
+#define NRF24_CPOL  CPOL
+#define NRF24_CPHA  CPHA
+#define NRF24_SPR0  SPR0
+
+#define NRF24_SPSR	SPSR0
+#define NRF24_SPIF  SPIF
+#define NRF24_SPI2X SPI2X
+
+#define NRF24_SPDR	SPDR0
+
+
 #define set_bit(reg,bit) reg |= (1<<bit)
 #define clr_bit(reg,bit) reg &= ~(1<<bit)
 #define check_bit(reg,bit) (reg&(1<<bit))
@@ -18,22 +60,27 @@
 /* ------------------------------------------------------------------------- */
 void nrf24_setupPins()
 {
-    set_bit(DDRA,0); // CE output
-    set_bit(DDRA,1); // CSN output
-    set_bit(DDRA,2); // SCK output
-    set_bit(DDRA,3); // MOSI output
-    clr_bit(DDRA,4); // MISO input
+  set_bit(NRF24_DDR_CE,NRF24_BIT_CE); // CE output
+  set_bit(NRF24_DDR_CS,NRF24_BIT_CS); // CSN output
+  set_bit(NRF24_DDR_SCK,NRF24_BIT_SCK); // SCK output
+  set_bit(NRF24_DDR_MOSI,NRF24_BIT_MOSI); // MOSI output
+  clr_bit(NRF24_DDR_MISO,NRF24_BIT_MISO); // MISO input
+
+#ifdef USE_HARDWARE_SPI
+	NRF24_SPCR = (0<<NRF24_SPIE) | (1<<NRF24_SPE) | (0<<NRF24_DORD) | (1<<NRF24_MSTR) | (0<< NRF24_CPOL) | (0<<NRF24_CPHA) | (0<<NRF24_SPR0);
+	NRF24_SPSR = (1<<NRF24_SPI2X);
+#endif
 }
 /* ------------------------------------------------------------------------- */
 void nrf24_ce_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTA,0);
+        set_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
     else
     {
-        clr_bit(PORTA,0);
+        clr_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -41,11 +88,11 @@ void nrf24_csn_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTA,1);
+        set_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
     else
     {
-        clr_bit(PORTA,1);
+        clr_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -53,11 +100,11 @@ void nrf24_sck_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTA,2);
+        set_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
     else
     {
-        clr_bit(PORTA,2);
+        clr_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -65,16 +112,34 @@ void nrf24_mosi_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(PORTA,3);
+        set_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
     else
     {
-        clr_bit(PORTA,3);
+        clr_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
 }
 /* ------------------------------------------------------------------------- */
 uint8_t nrf24_miso_digitalRead()
 {
-    return check_bit(PINA,4);
+    return check_bit(NRF24_PIN_MISO,NRF24_BIT_MISO);
+}
+/* ------------------------------------------------------------------------- */
+
+#ifndef USE_HARDWARE_SPI
+extern uint8_t spi_transfer_SW(uint8_t tx);
+#endif
+uint8_t spi_transfer(uint8_t tx)
+{
+#ifdef USE_HARDWARE_SPI
+  uint8_t rx = 0;
+
+  NRF24_SPDR = tx;
+  while ( !(NRF24_SPSR & (1<<NRF24_SPIF)) ) {} //wait until done
+  rx = NRF24_SPDR;
+  return rx;
+#else
+  return spi_transfer_SW(tx);
+#endif
 }
 /* ------------------------------------------------------------------------- */

--- a/tx_example/radioPinFunctions.c
+++ b/tx_example/radioPinFunctions.c
@@ -11,35 +11,76 @@
 
 #include <avr/io.h>
 
-// Modify these variables to customize the ports/pins the RF module will use
-#define RF_DDR  DDRC
-#define RF_PORT PORTC
-#define RF_PIN  PINC
+//#define USE_HARDWARE_SPI
+
+//IO pin register and bit mapping
+#define NRF24_DDR_MISO	DDRC
+#define NRF24_PORT_MISO	PORTC
+#define NRF24_PIN_MISO	PINC
+#define NRF24_BIT_MISO	4
+#define NRF24_DDR_MOSI	DDRC
+#define NRF24_PORT_MOSI	PORTC
+#define NRF24_BIT_MOSI	3
+#define NRF24_DDR_SCK	  DDRC
+#define NRF24_PORT_SCK	PORTC
+#define NRF24_BIT_SCK	  2
+#define NRF24_DDR_CS	  DDRC
+#define NRF24_PORT_CS	  PORTC
+#define NRF24_BIT_CS	  1
+#define NRF24_DDR_CE	  DDRC
+#define NRF24_PORT_CE	  PORTC
+#define NRF24_BIT_CE	  0
+
+//IRQ pin (currently not used)
+#define NRF24_DDR_IRQ	  DDRB
+#define NRF24_PORT_IRQ	PORTB
+#define NRF24_BIT_IRQ	  2
+
+//SPI register and bit remapping (some have SPCR, others SPCR0, etc.)
+#define NRF24_SPCR	SPCR0
+#define NRF24_SPIE  SPIE
+#define NRF24_SPE   SPE
+#define NRF24_DORD  DORD
+#define NRF24_MSTR  MSTR
+#define NRF24_CPOL  CPOL
+#define NRF24_CPHA  CPHA
+#define NRF24_SPR0  SPR0
+
+#define NRF24_SPSR	SPSR0
+#define NRF24_SPIF  SPIF
+#define NRF24_SPI2X SPI2X
+
+#define NRF24_SPDR	SPDR0
+
 
 #define set_bit(reg,bit) reg |= (1<<bit)
 #define clr_bit(reg,bit) reg &= ~(1<<bit)
 #define check_bit(reg,bit) (reg&(1<<bit))
 
 /* ------------------------------------------------------------------------- */
-
 void nrf24_setupPins()
 {
-    set_bit(RF_DDR,0); // CE output
-    set_bit(RF_DDR,1); // CSN output
-    set_bit(RF_DDR,2); // SCK output
-    set_bit(RF_DDR,3); // MOSI output
-    clr_bit(RF_DDR,4); // MISO input
+  set_bit(NRF24_DDR_CE,NRF24_BIT_CE); // CE output
+  set_bit(NRF24_DDR_CS,NRF24_BIT_CS); // CSN output
+  set_bit(NRF24_DDR_SCK,NRF24_BIT_SCK); // SCK output
+  set_bit(NRF24_DDR_MOSI,NRF24_BIT_MOSI); // MOSI output
+  clr_bit(NRF24_DDR_MISO,NRF24_BIT_MISO); // MISO input
+
+#ifdef USE_HARDWARE_SPI
+	NRF24_SPCR = (0<<NRF24_SPIE) | (1<<NRF24_SPE) | (0<<NRF24_DORD) | (1<<NRF24_MSTR) | (0<< NRF24_CPOL) | (0<<NRF24_CPHA) | (0<<NRF24_SPR0);
+	NRF24_SPSR = (1<<NRF24_SPI2X);
+#endif
 }
 /* ------------------------------------------------------------------------- */
 void nrf24_ce_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(RF_PORT,0);
+        set_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
     else
     {
-        clr_bit(RF_PORT,0);
+        clr_bit(NRF24_PORT_CE,NRF24_BIT_CE);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -47,11 +88,11 @@ void nrf24_csn_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(RF_PORT,1);
+        set_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
     else
     {
-        clr_bit(RF_PORT,1);
+        clr_bit(NRF24_PORT_CS,NRF24_BIT_CS);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -59,11 +100,11 @@ void nrf24_sck_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(RF_PORT,2);
+        set_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
     else
     {
-        clr_bit(RF_PORT,2);
+        clr_bit(NRF24_PORT_SCK,NRF24_BIT_SCK);
     }
 }
 /* ------------------------------------------------------------------------- */
@@ -71,16 +112,34 @@ void nrf24_mosi_digitalWrite(uint8_t state)
 {
     if(state)
     {
-        set_bit(RF_PORT,3);
+        set_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
     else
     {
-        clr_bit(RF_PORT,3);
+        clr_bit(NRF24_PORT_MOSI,NRF24_BIT_MOSI);
     }
 }
 /* ------------------------------------------------------------------------- */
 uint8_t nrf24_miso_digitalRead()
 {
-    return check_bit(RF_PIN,4);
+    return check_bit(NRF24_PIN_MISO,NRF24_BIT_MISO);
+}
+/* ------------------------------------------------------------------------- */
+
+#ifndef USE_HARDWARE_SPI
+extern uint8_t spi_transfer_SW(uint8_t tx);
+#endif
+uint8_t spi_transfer(uint8_t tx)
+{
+#ifdef USE_HARDWARE_SPI
+  uint8_t rx = 0;
+
+  NRF24_SPDR = tx;
+  while ( !(NRF24_SPSR & (1<<NRF24_SPIF)) ) {} //wait until done
+  rx = NRF24_SPDR;
+  return rx;
+#else
+  return spi_transfer_SW(tx);
+#endif
 }
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
function spi_transfer to radioPinFunctions.c, where it can either call the spi_transfer_SW function (fallback to bit-banging) or implement it's own version of SPI transfer, preferably using the built-in SPI module.

Also added a bunch of macros to the radioPinFunctions.c in all the examples to ease migration to different hardware within the ATmega/ATtiny family of uCs.